### PR TITLE
Working 2 and 3 addends for PBS and CBS

### DIFF
--- a/parasol_runtime/examples/op_noise/args.rs
+++ b/parasol_runtime/examples/op_noise/args.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use clap::{Args, Parser, Subcommand};
-use parasol_runtime::{DEFAULT_128, Params};
+use parasol_runtime::{DEFAULT_128, FAST_BIG_128, Params, TURBO_CHUNGUS_128};
 use serde::{Deserialize, Serialize};
 
 use crate::cmux_tree::CMuxTreeParameters;
@@ -147,40 +147,42 @@ pub struct SearchSchemeSwitchCommand {
 
 #[derive(Debug, Args)]
 pub struct AnalyzeCbs {
-    #[arg(default_value_t = 3, long)]
-    /// The radix decomposition count of the scheme switch operation.
-    pub ss_radix_count: usize,
-
-    #[arg(default_value_t = 15, long)]
-    /// The radix decomposition base-log of the scheme switch operation.
-    pub ss_radix_log: usize,
-
-    #[arg(default_value_t = 2, long)]
-    /// The radix decomposition count of the pbs operation.
-    pub pbs_radix_count: usize,
-
-    #[arg(default_value_t = 16, long)]
-    /// The radix decomposition base-log of the pbs operation.
-    pub pbs_radix_log: usize,
-
-    #[arg(default_value_t = 6, long)]
-    /// The radix decomposition count of the tr operation.
-    pub tr_radix_count: usize,
-
-    #[arg(default_value_t = 7, long)]
-    /// The radix decomposition base-log of the tr operation.
-    pub tr_radix_log: usize,
+    #[arg(default_value_t = 4, long)]
+    /// The radix decomposition base-log of the resulting GGSW.
+    pub cbs_radix_log: usize,
 
     #[arg(default_value_t = 4, long)]
     /// The radix decomposition count of the resulting GGSW.
     pub cbs_radix_count: usize,
 
-    #[arg(default_value_t = 4, long)]
-    /// The radix decomposition base-log of the resulting GGSW.
-    pub cbs_radix_log: usize,
+    #[arg(default_value_t = 16, long)]
+    /// The radix decomposition base-log of the pbs operation.
+    pub pbs_radix_log: usize,
+
+    #[arg(default_value_t = 2, long)]
+    /// The radix decomposition count of the pbs operation.
+    pub pbs_radix_count: usize,
+
+    #[arg(default_value_t = 3, long)]
+    /// The radix decomposition base-log of the scheme switch operation.
+    pub ss_radix_log: usize,
+
+    #[arg(default_value_t = 15, long)]
+    /// The radix decomposition count of the scheme switch operation.
+    pub ss_radix_count: usize,
+
+    #[arg(default_value_t = 7, long)]
+    /// The radix decomposition base-log of the tr operation.
+    pub tr_radix_log: usize,
+
+    #[arg(default_value_t = 6, long)]
+    /// The radix decomposition count of the tr operation.
+    pub tr_radix_count: usize,
 
     #[arg(default_value_t = 7.25e-5, long)]
-    /// The std deviation of the L0 LWE instance.
+    /// The std deviation of the L0 LWE instance. See
+    /// `sunscreen_tfhe/src/params.rs` for LWE for parameter sets for what this
+    /// number should be for a given LWE size and security level.
     pub l0_sigma: f64,
 
     #[arg(default_value_t = 7e-16, long)]
@@ -188,11 +190,15 @@ pub struct AnalyzeCbs {
     pub l1_sigma: f64,
 
     #[arg(default_value_t = 7.25e-5, long)]
-    /// The std deviation given to the input L0 LWE ciphertext.
+    /// The std deviation given to the input L0 LWE ciphertext. See
+    /// `sunscreen_tfhe/src/params.rs` for LWE for parameter sets for what this
+    /// number should be for a given LWE size and security level.
     pub input_sigma: f64,
 
     #[arg(default_value_t = 637, long)]
-    /// The number of polynomials in the GLWE problem instance.
+    /// The number of polynomials in the GLWE problem instance. See
+    /// `sunscreen_tfhe/src/params.rs` for LWE for parameter sets for what this
+    /// number should be for a given LWE size and security level.
     pub l0_lwe_size: usize,
 
     #[arg(default_value_t = 1, long)]
@@ -309,6 +315,8 @@ impl AnalyzeCMuxTreeSource {
                 let parameter_set = match parameter_set_name.to_lowercase().as_str() {
                     "default" => Params::default(),
                     "default_128" => DEFAULT_128,
+                    "fast_big_128" => FAST_BIG_128,
+                    "turbo_chungus_128" => TURBO_CHUNGUS_128,
                     _ => Err(anyhow!("Invalid parameter set"))?,
                 };
                 Ok(CMuxTreeParameters {

--- a/parasol_runtime/examples/op_noise/cmux_tree.rs
+++ b/parasol_runtime/examples/op_noise/cmux_tree.rs
@@ -516,7 +516,7 @@ fn run_compute_tree(
 
     let mut samples_per_level = Vec::with_capacity(depth);
 
-    for (order, select_1, select_2) in permutation.iter() {
+    for (level, (order, select_1, select_2)) in permutation.iter().enumerate() {
         let outputs @ (out_a_expected, out_b_expected) = match order {
             Order::Normal => (last_inputs.0, last_inputs.1),
             Order::Flipped => (last_inputs.1, last_inputs.0),
@@ -539,6 +539,10 @@ fn run_compute_tree(
             PlaintextBits(1),
         );
 
+        if noise_a.is_err() {
+            eprintln!("Error measuring noise in CMUX tree at level {level}");
+        }
+
         let noise_b = measure_noise_by_keyswitch_glwe_to_lwe(
             &out_b,
             &secret_key.lwe_0,
@@ -547,6 +551,10 @@ fn run_compute_tree(
             params,
             PlaintextBits(1),
         );
+
+        if noise_b.is_err() {
+            eprintln!("Error measuring noise in CMUX tree at level {level}");
+        }
 
         // Concat the samples.
         samples_per_level.push((noise_a, noise_b));
@@ -711,16 +719,20 @@ fn drift_analysis(
         .collect::<Vec<_>>();
     progress.finish_and_clear();
 
+    let noise_decode_error_msg =
+        |depth| format!("Expected a sample noise but received None instead at depth {depth}");
     let samples_per_tree = samples_per_run
         .into_iter()
         .flat_map(|x| {
             let left = x
                 .iter()
-                .map(|(a, _)| a.unwrap().clone())
+                .enumerate()
+                .map(|(i, (a, _))| a.expect(&noise_decode_error_msg(i)).clone())
                 .collect::<Vec<_>>();
             let right = x
                 .iter()
-                .map(|(_, b)| b.unwrap().clone())
+                .enumerate()
+                .map(|(i, (_, b))| b.expect(&noise_decode_error_msg(i)).clone())
                 .collect::<Vec<_>>();
 
             [left, right]

--- a/parasol_runtime/src/params.rs
+++ b/parasol_runtime/src/params.rs
@@ -151,8 +151,8 @@ pub const DEFAULT_128: Params = Params {
         count: RadixCount(15),
     },
     tr_radix: RadixDecomposition {
-        count: RadixCount(6),
         radix_log: RadixLog(7),
+        count: RadixCount(6),
     },
     addend_count: AddendCount(1),
 };
@@ -182,8 +182,8 @@ pub const FAST_BIG_128: Params = Params {
         count: RadixCount(15),
     },
     tr_radix: RadixDecomposition {
-        count: RadixCount(6),
         radix_log: RadixLog(7),
+        count: RadixCount(6),
     },
     addend_count: AddendCount(2),
 };
@@ -213,8 +213,8 @@ pub const TURBO_CHUNGUS_128: Params = Params {
         count: RadixCount(15),
     },
     tr_radix: RadixDecomposition {
-        count: RadixCount(6),
         radix_log: RadixLog(7),
+        count: RadixCount(6),
     },
     addend_count: AddendCount(3),
 };

--- a/sunscreen_tfhe/src/entities/univariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/univariate_lookup_table.rs
@@ -54,7 +54,7 @@ impl<S: TorusOps> UnivariateLookupTable<S> {
     /// # Remarks
     /// The result of this should be used with
     /// [`generalized_programmable_bootstrap`](crate::ops::bootstrapping::generalized_programmable_bootstrap).
-    pub fn trivivial_multifunctional<F>(
+    pub fn trivial_multifunctional<F>(
         maps: &[F],
         glwe: &GlweDef,
         plaintext_bits: PlaintextBits,
@@ -86,7 +86,7 @@ impl<S: TorusOps> UnivariateLookupTableRef<S> {
         GlweCiphertextRef::from_mut_slice(&mut self.data)
     }
 
-    /// Generates a look up table filled with the values from the provided map,
+    /// Generates a look up table filled with the values from the provided maps,
     /// and trivially encrypts the lookup table.
     pub fn fill_trivial_from_fns<F: Fn(u64) -> u64>(
         &mut self,

--- a/sunscreen_tfhe/src/gpu/tests/bootstrapping.rs
+++ b/sunscreen_tfhe/src/gpu/tests/bootstrapping.rs
@@ -56,7 +56,7 @@ fn can_programmable_bootstrap() {
 
         // Fill the LUT with nonsense and we'll overwrite it with
         // the correct encoding.
-        let lut = UnivariateLookupTable::<u64>::trivivial_multifunctional(
+        let lut = UnivariateLookupTable::<u64>::trivial_multifunctional(
             [|x| x % 2, |x| (x + 1) % 2, |x| x % 2].as_slice(),
             &glwe,
             bits,

--- a/sunscreen_tfhe/src/ops/bootstrapping/circuit_bootstrapping.rs
+++ b/sunscreen_tfhe/src/ops/bootstrapping/circuit_bootstrapping.rs
@@ -349,7 +349,7 @@ fn mod_switch_trace_and_rotate<S>(
 /// bandwidth bottlenecking.
 ///
 /// In fact, this algorithm's runtime is over 90% dominated by the programmable
-/// bootstrap operation even under agressive radix decompositions.
+/// bootstrap operation even under aggressive radix decompositions.
 pub fn circuit_bootstrap_via_trace_and_scheme_switch<S>(
     output: &mut GgswCiphertextFftRef<Complex<f64>>,
     input: &LweCiphertextRef<S>,
@@ -535,10 +535,9 @@ mod tests {
 
     use crate::{
         GLWE_1_2048_128, LWE_637_128, PlaintextBits, RadixCount, RadixDecomposition, RadixLog,
-        dst::AsSlice,
         entities::{
             AutomorphismKey, AutomorphismKeyFft, DstArray, GgswCiphertext, GgswCiphertextFft,
-            GlweCiphertext, LweCiphertext, SchemeSwitchKey, SchemeSwitchKeyFft,
+            GlweCiphertext, LweCiphertext, Polynomial, SchemeSwitchKey, SchemeSwitchKeyFft,
         },
         high_level::{self, TEST_LWE_DEF_1, encryption, fft, keygen},
         ops::{
@@ -752,27 +751,45 @@ mod tests {
         }
     }
 
-    #[test]
-    fn can_circuit_bootstrap_via_trace_ss() {
+    struct FailedBootstrapGGSW {
+        value: u64,
+        glev_index: usize,
+        glwe_index: usize,
+        actual: Polynomial<u64>,
+        expected: Polynomial<u64>,
+    }
+
+    impl std::fmt::Display for FailedBootstrapGGSW {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "Failed bootstrapping value {} at GLEV index {}, GLWE index {}: actual = {:?}, expected = {:?}",
+                self.value, self.glev_index, self.glwe_index, self.actual, self.expected
+            )
+        }
+    }
+
+    fn circuit_bootstrap_via_trace_ss(addend_count: u32) {
         let pbs_radix = RadixDecomposition {
-            count: RadixCount(2),
             radix_log: RadixLog(15),
+            count: RadixCount(2),
         };
         let cbs_radix = RadixDecomposition {
-            count: RadixCount(4),
             radix_log: RadixLog(4),
+            count: RadixCount(4),
         };
         let tr_radix = RadixDecomposition {
-            count: RadixCount(6),
             radix_log: RadixLog(7),
+            count: RadixCount(6),
         };
         let ss_radix = RadixDecomposition {
-            count: RadixCount(2),
-            radix_log: RadixLog(17),
+            radix_log: RadixLog(3),
+            count: RadixCount(15),
         };
+
         let lwe = LWE_637_128;
         let glwe = GLWE_1_2048_128;
-        let addend_count = AddendCount(1);
+        let addend_count = AddendCount(addend_count);
 
         let lwe_sk = keygen::generate_binary_lwe_sk(&lwe);
         let glwe_sk = keygen::generate_binary_glwe_sk(&glwe);
@@ -797,6 +814,8 @@ mod tests {
         let mut ak_fft = AutomorphismKeyFft::new(&glwe, &tr_radix);
         ak.fft(&mut ak_fft, &glwe, &tr_radix);
 
+        let mut failed = Vec::new();
+
         for b in [0, 1] {
             let ct = lwe_sk.encrypt(b, &lwe, PlaintextBits(1)).0;
 
@@ -819,31 +838,66 @@ mod tests {
 
             let mut actual_ifft = GgswCiphertext::new(&glwe, &cbs_radix);
 
-            dbg!(actual.as_slice());
-
             actual.ifft(&mut actual_ifft, &glwe, &cbs_radix);
 
             let expected =
                 encryption::encrypt_ggsw(b, &glwe_sk, &glwe, &cbs_radix, PlaintextBits(1));
 
-            for (a, e) in actual_ifft
+            for (glev_index, (a, e)) in actual_ifft
                 .rows(&glwe, &cbs_radix)
                 .zip(expected.rows(&glwe, &cbs_radix))
+                .enumerate()
             {
-                for (i, (a, e)) in a
+                for (glwe_index, (a, e)) in a
                     .glwe_ciphertexts(&glwe)
                     .zip(e.glwe_ciphertexts(&glwe))
                     .enumerate()
                 {
-                    let plaintext_bits = (i + 1) * cbs_radix.radix_log.0;
+                    let plaintext_bits = (glwe_index + 1) * cbs_radix.radix_log.0;
                     let plaintext_bits = PlaintextBits(plaintext_bits as u32);
 
                     let a = encryption::decrypt_glwe(a, &glwe_sk, &glwe, plaintext_bits);
                     let e = encryption::decrypt_glwe(e, &glwe_sk, &glwe, plaintext_bits);
 
-                    assert_eq!(a, e);
+                    if a != e {
+                        failed.push(FailedBootstrapGGSW {
+                            value: b,
+                            glev_index,
+                            glwe_index,
+                            actual: a,
+                            expected: e,
+                        });
+                    }
                 }
             }
+        }
+
+        if !failed.is_empty() {
+            for fail in &failed {
+                eprintln!("{}", fail);
+            }
+            panic!("Bootstrapping failed with {} errors", failed.len());
+        }
+    }
+
+    #[test]
+    fn can_circuit_bootstrap_via_trace_ss_1_addend() {
+        for _ in 0..6 {
+            circuit_bootstrap_via_trace_ss(1);
+        }
+    }
+
+    #[test]
+    fn can_circuit_bootstrap_via_trace_ss_2_addends() {
+        for _ in 0..6 {
+            circuit_bootstrap_via_trace_ss(2);
+        }
+    }
+
+    #[test]
+    fn can_circuit_bootstrap_via_trace_ss_3_addends() {
+        for _ in 0..6 {
+            circuit_bootstrap_via_trace_ss(3);
         }
     }
 }

--- a/sunscreen_tfhe/src/ops/bootstrapping/programmable_bootstrapping.rs
+++ b/sunscreen_tfhe/src/ops/bootstrapping/programmable_bootstrapping.rs
@@ -397,7 +397,7 @@ pub fn programmable_bootstrap_univariate<S>(
 /// [`programmable_bootstrap_bivariate`] compute a single function of the
 /// input ciphertext, this can compute multiple functions. To do this,
 /// create a [`UnivariateLookupTable`](crate::entities::UnivariateLookupTable) using
-/// [`UnivariateLookupTable::trivivial_multifunctional`](crate::entities::UnivariateLookupTable::trivivial_multifunctional).
+/// [`UnivariateLookupTable::trivial_multifunctional`](crate::entities::UnivariateLookupTable::trivial_multifunctional).
 ///
 /// `log_chi` is the number of most-significant bits to drop during
 /// bootstrapping. Generally, you should set this to zero unless building

--- a/sunscreen_tfhe/src/ops/bootstrapping/programmable_bootstrapping.rs
+++ b/sunscreen_tfhe/src/ops/bootstrapping/programmable_bootstrapping.rs
@@ -22,9 +22,7 @@ use crate::{
         },
         encryption::encrypt_ggsw_ciphertext_scalar,
         fft_ops::{cmux, glwe_ggsw_mad},
-        homomorphisms::{
-            mad_ggsw_ciphertext_positive_monomial_fft, msub_ggsw_ciphertext_positive_monomial_fft,
-        },
+        homomorphisms::mad_ggsw_ciphertext_positive_monomial_fft,
     },
     scratch::allocate_scratch_ref,
 };
@@ -34,7 +32,9 @@ use super::rotate_glwe_negative_monomial_negacyclic;
 /// Generate a bootstrap key from a LWE secret key to a GLWE secret key.
 ///
 /// Mathematically, this key is a list of GGSW ciphertexts, one for each bit of
-/// the secret key being encrypted.
+/// the secret key being encrypted (for the case of one addend) or a bundle of
+/// GGSW ciphertexts for each `addend` group of bits of the secret key (for the case of
+/// multiple addends).
 ///
 /// See
 /// [`programmable_bootstrap_univariate`](crate::ops::bootstrapping::programmable_bootstrap_univariate)
@@ -90,27 +90,32 @@ fn generate_key_bundle<S>(
         return;
     }
 
-    // Otherwise, generate the keybundle of all permutations of s_i and !s_i.
-    //
-    // Iterate over all the truth table configurations for the bundle of secret key bits.
-    // If the j'th bit of i is a zero, we invert s_i for its contributing in the product
-    // of s_i terms. Otherwise, we just take s_i as-is.
-    #[allow(clippy::needless_range_loop)]
-    for i in 0..bundle_size {
-        let kb = sk_bits
-            .iter()
-            .enumerate()
-            .map(|(j, x)| {
-                if (i >> j) & 0x1 == 1 {
-                    *x
-                } else {
-                    !*x & <S as num::One>::one()
-                }
-            })
-            .fold(<S as num::One>::one(), |s, x| s & x);
-
-        encrypt_ggsw_ciphertext_scalar(enc_sk[i], kb, glwe_sk, glwe, radix, plaintext_bits);
+    // Compute the one-hot encoding of the bits in the secret key.
+    for (i, ggsw) in enc_sk.iter_mut().enumerate() {
+        let kb = is_one_hot(i, sk_bits);
+        encrypt_ggsw_ciphertext_scalar(ggsw, kb, glwe_sk, glwe, radix, plaintext_bits);
     }
+}
+
+/// Computes whether a position is the one-hot position for the given bits.
+/// This counts up from the left (i.e., the least significant bit is at the
+/// start of the slice).
+#[inline(always)]
+fn is_one_hot<S>(position: usize, sk_bits: &[S]) -> S
+where
+    S: TorusOps,
+{
+    sk_bits
+        .iter()
+        .enumerate()
+        .map(|(j, x)| {
+            if (position >> j) & 0x1 == 1 {
+                *x
+            } else {
+                !*x & <S as num::One>::one()
+            }
+        })
+        .fold(<S as num::One>::one(), |s, x| s & x)
 }
 
 /// Generate a negacyclic LUT for bootstrapping. Another name for this structure
@@ -174,8 +179,8 @@ fn generate_negacyclic_lut<S, F>(
 /// not negacyclic, and hence must be used with LWE inputs that have at least
 /// one padding bit.
 ///
-/// The input `map` is used for generating programmable bootstrapping LUTs. This
-/// function takes an element in the plaintext space and must produce another
+/// The input `maps` is used for generating programmable bootstrapping LUTs. These
+/// functions takes an element in the plaintext space and must produce another
 /// element in the plaintext space.
 ///
 /// # Remarks
@@ -394,13 +399,13 @@ pub fn programmable_bootstrap_univariate<S>(
 /// create a [`UnivariateLookupTable`](crate::entities::UnivariateLookupTable) using
 /// [`UnivariateLookupTable::trivivial_multifunctional`](crate::entities::UnivariateLookupTable::trivivial_multifunctional).
 ///
-/// `log_v` should equal `ceil(log2(maps.len()))` for the `maps` you
-/// used when creating the LUT.
-///
 /// `log_chi` is the number of most-significant bits to drop during
 /// bootstrapping. Generally, you should set this to zero unless building
 /// other cryptographic primitives, such as Without Padding Bootstrapping
 /// (WoP-PBS)
+///
+/// `log_v` should equal `ceil(log2(maps.len()))` for the `maps` you
+/// used when creating the LUT.
 pub fn generalized_programmable_bootstrap<S>(
     output: &mut GlweCiphertextRef<S>,
     input: &LweCiphertextRef<S>,
@@ -426,7 +431,8 @@ pub fn generalized_programmable_bootstrap<S>(
 
     // Steps:
     // 1. Modulus switch the ciphertext to 2N.
-    // 2. Blind rotate V using the elements of the bootstrap key (the input LWE secret key bits). The algorithm for this depends on addend_count.
+    // 2. Blind rotate V using the elements of the bootstrap key (the input LWE
+    //    secret key bits). The algorithm for this depends on addend_count.
     // 3. Sample extract.
     // 4. (Optional, done outside of this method) Key switch to the output LWE
     // secret key (should be the one extracted from the GLWE key).
@@ -567,7 +573,35 @@ fn apply_addends<'a, IA, IBSK, S>(
 
         assert!(bsk_bundle.next().is_none());
         assert!(a.next().is_none());
-    } else if addend_count.0 == 2 {
+    }
+    // TODO: The following code for addend counts 2 and 3 is not quite the
+    // formulas that are specified in the paper. In the paper, terms are either
+    // added or subtracted based on if the number of set secret key bits for the
+    // number of addends is even or odd (subtract for odd). For example, for the
+    // 2 addends case, the formula in the paper is
+    //
+    //   X^{-a_{i - 1} - a_i} s_i s_{i - 1}
+    // - X^{-a_{i - 1}} s_{i - 1} (s_i - 1)
+    // - X^{-a_i} s_i (s_{i - 1} - 1)
+    // + (s_i - 1)(s_{i - 1} - 1)
+    //
+    // In this case, the negatives in front of the second and third terms are
+    // due to the bit selecting the particular term in the truth table above is
+    // -1 (ex: s_i - 1, where s_i is 0, produces -1).
+    //
+    // This did not immediately work when implemented for CBS, potentially due
+    // to the fact that what the encoding of -1 is changes based on the number
+    // of plaintext bits needed (which changes during the bootstrapping
+    // procedure). Instead, we encode the truth table using only positive terms:
+    //
+    //   X^{-a_{i - 1} - a_i} s_i s_{i - 1}
+    // + X^{-a_{i - 1}} s_{i - 1} (1 - s_i)
+    // + X^{-a_i} s_i (1 - s_{i - 1})
+    // + (1 - s_i)(1 - s_{i - 1})
+    //
+    // While this work in theory and in practice is fine, we should double check
+    // that it is the approach that we want to take.
+    else if addend_count.0 == 2 {
         let a_i_min_1 = a.next().unwrap().to_u64() as usize;
         let a_i = a.next().unwrap().to_u64() as usize;
         assert!(a.next().is_none());
@@ -587,7 +621,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         sum_addends.clone_from_ref(bsk_bundle.next().unwrap());
 
         // a_(i - 1)(s_i - 1)(s_(i - 1))
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i_min_1,
@@ -596,7 +630,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         );
 
         // a_i(s_i)(s_(i - 1) - 1)
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i,
@@ -642,7 +676,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         sum_addends.clone_from_ref(bsk_bundle.next().unwrap());
 
         // a^{i - 2} ⊠ ((s_{i} - 1) (s_{i - 1} - 1) s_{i - 2})
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i_min_2,
@@ -651,7 +685,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         );
 
         // a^{i - 1} ⊠ ((s_{i} - 1) s_{i - 1} (s_{i - 2} - 1))
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i_min_1,
@@ -669,7 +703,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         );
 
         // a^{i} ⊠ ( s_{i} (s_{i - 1} - 1) (s_{i - 2} - 1))
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i,
@@ -696,7 +730,7 @@ fn apply_addends<'a, IA, IBSK, S>(
         );
 
         // a^{i} a^{i - 1} a^{i - 2} ⊠ (s_{i} s_{i - 1} s_{i - 2})
-        msub_ggsw_ciphertext_positive_monomial_fft(
+        mad_ggsw_ciphertext_positive_monomial_fft(
             sum_addends,
             bsk_bundle.next().unwrap(),
             a_i + a_i_min_1 + a_i_min_2,
@@ -710,6 +744,8 @@ fn apply_addends<'a, IA, IBSK, S>(
 
         // acc *= sum_addends
         glwe_ggsw_mad(result, accumulator, sum_addends, glwe_params, radix);
+
+        result.ifft(accumulator, glwe_params);
     }
 }
 
@@ -1271,15 +1307,11 @@ mod tests {
 
         // Fill the LUT with nonsense and we'll overwrite it with
         // the correct encoding.
-        let lut = UnivariateLookupTable::trivivial_multifunctional(
-            [|x| x % 2, |x| (x + 1) % 2, |x| x % 2].as_slice(),
-            glwe,
-            bits,
-        );
+        let maps = [|x| x % 2, |x| (x + 1) % 2, |x| x % 2];
+        let lut = UnivariateLookupTable::trivial_multifunctional(maps.as_slice(), glwe, bits);
 
         for i in [0, 1] {
-            //let input = encryption::encrypt_lwe_secret(i, &lwe_sk, lwe, bits);
-            let input = encryption::trivial_lwe(i, lwe, PlaintextBits(2));
+            let input = encryption::encrypt_lwe_secret(i, &lwe_sk, lwe, PlaintextBits(2));
             let mut output = GlweCiphertext::new(glwe);
 
             generalized_programmable_bootstrap(
@@ -1288,7 +1320,7 @@ mod tests {
                 &lut,
                 &bs_key,
                 0,
-                3,
+                maps.len().next_power_of_two().ilog2(),
                 lwe,
                 glwe,
                 radix,
@@ -1321,17 +1353,23 @@ mod tests {
 
     #[test]
     fn can_generalized_bootstrap() {
-        generalized_bootstrap_case(AddendCount(1));
+        for _ in 0..6 {
+            generalized_bootstrap_case(AddendCount(1));
+        }
     }
 
     #[test]
     fn can_generalized_bootstrap_2_addends() {
-        generalized_bootstrap_case(AddendCount(2));
+        for _ in 0..6 {
+            generalized_bootstrap_case(AddendCount(2));
+        }
     }
 
     #[test]
     fn can_generalized_bootstrap_3_addends() {
-        generalized_bootstrap_case(AddendCount(3));
+        for _ in 0..6 {
+            generalized_bootstrap_case(AddendCount(3));
+        }
     }
 
     #[test]
@@ -1356,6 +1394,56 @@ mod tests {
 
         // 8 elements for the first 130 / 3 elements + 4 for the remaining 2 elements
         assert_eq!(bootstrap_key.rows(&glwe, &radix).len(), 43 * 8 + 4);
+    }
+
+    #[test]
+    fn test_truth_table_generation_2_bits() {
+        // Test every position for every possible 2-bit input
+        let test_cases = [
+            ([0u64, 0u64], 0),
+            ([1u64, 0u64], 1),
+            ([0u64, 1u64], 2),
+            ([1u64, 1u64], 3),
+        ];
+
+        for (input_bits, expected_hot_pos) in test_cases.iter() {
+            for pos in 0..4 {
+                let result = is_one_hot(pos, input_bits) == 1;
+                let expected = pos == *expected_hot_pos;
+                assert_eq!(
+                    result, expected,
+                    "Position {} should be {} for input {:?}",
+                    pos, expected, input_bits
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_truth_table_generation_3_bits() {
+        // Test every position for every possible 3-bit input
+        let test_cases = [
+            ([0u64, 0u64, 0u64], 0),
+            ([1u64, 0u64, 0u64], 1),
+            ([0u64, 1u64, 0u64], 2),
+            ([1u64, 1u64, 0u64], 3),
+            ([0u64, 0u64, 1u64], 4),
+            ([1u64, 0u64, 1u64], 5),
+            ([0u64, 1u64, 1u64], 6),
+            ([1u64, 1u64, 1u64], 7),
+        ];
+
+        for (input_bits, expected_hot_pos) in test_cases.iter() {
+            for pos in 0..8 {
+                let result = is_one_hot(pos, input_bits) == 1;
+                let expected = pos == *expected_hot_pos;
+                assert_eq!(
+                    result, expected,
+                    "Position {} should be {} for input {:?}",
+                    pos, expected, input_bits
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
A few changes were made:

- The main change is in the mathematical formulation; instead of encrypting +1 or -1 in the bootstrapping key bundle, we always encrypt just +1 and adjust the addends formulas appropriately.
- The scheme switch parameters were switched between the radix log and the radix count in tests and in the noise measurement; this did not cause significant issue but has been fixed.
- Missing IFFT for the 3 addend case.
- Testing the PBS against a trivial bootstrap meant that any rotations involing the a terms in a ciphertext were ignored.